### PR TITLE
Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ __pycache__
 
 # temp
 /temp/
+
+# CMake
+cmake-build-*/
+
+# IDEA
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - cd build_runtime
   - cmake ../compiler/extensions/cpp/runtime/ -GNinja
   - cmake --build . --config Release
-  - ctest -C Release -V
+  - ctest -C Release -V --output-on-failure
 
 before_install:
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,12 +42,8 @@ matrix:
             - ninja-build
       env:
         - JOB_NAME=runtime_cppcheck
-        - CC=gcc-4.9
-        - CXX=g++-4.9
       script:
-        - mkdir -p build_runtime
-        - cd build_runtime
-        - cppcheck ../compiler/extensions/cpp/runtime/
+        - cppcheck --platform=unix64 --enable=all --std=c++11 --max-configs=1 --inconclusive --check-config --suppress=missingIncludeSystem -I3rdparty/cpp/googletest/include compiler/extensions/cpp/runtime/src
 
     # Ant Test
     - language: java
@@ -77,7 +73,7 @@ matrix:
             - cppcheck
             - ninja-build
       after_success:
-        - cppcheck --platform=unix64 --enable=all --std=c++11 --max-configs=1 --inconclusive --check-config --suppress=missingIncludeSystem -Ithirdparty/runtime/ --suppress=*:*thirdparty* -Isrc/ src/
+        - cppcheck --platform=unix64 --enable=all --std=c++11 --max-configs=1 --inconclusive --check-config --suppress=missingIncludeSystem --suppress=*:*thirdparty* -Ithirdparty/runtime/ -Isrc/ src/
       env:
         - JOB_NAME=generated_cppcheck
         - CC=gcc-4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 
 # C++ project
 language: cpp
+dist: trusty
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,6 @@ script:
   - cd build_runtime
   - export CC=${CC_COMPILER}
   - export CXX=${CXX_COMPILER}
-  - cmake -DZSERIO_RUNTIME_INCLUDE_INSPECTOR ../compiler/extensions/cpp/runtime/ -GNinja
+  - cmake -DZSERIO_RUNTIME_INCLUDE_INSPECTOR=1 ../compiler/extensions/cpp/runtime/ -GNinja
   - cmake --build . --config Release
   - ctest -C Release -V --output-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-4.9
+            - ninja-build
       env:
         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ matrix:
         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
 
 before_install:
-  - eval "${MATRIX_EVAL}
+  - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,11 @@ matrix:
       env:
         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
 
+script:
+  - mkdir -p build_runtime
+  - cd build_runtime
+  - cmake ../compiler/extensions/cpp/runtime/ -GNinja
+  - cmake --build .
+
 before_install:
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 
 # C++ project
-language: cpp
 dist: trusty
 
 matrix:
   include:
-    # works on Precise and Trusty
-    - os: linux
+    # C++ Runtime Unit Tests
+    - language: cpp
+      os: linux
       compiler:
         - gcc
       addons:
@@ -17,14 +17,78 @@ matrix:
             - g++-4.9
             - ninja-build
       env:
-        - CC_COMPILER=gcc-4.9
-        - CXX_COMPILER=g++-4.9
+        - JOB_NAME=runtime_unit_test
+        - CC=gcc-4.9
+        - CXX=g++-4.9
+      script:
+        - mkdir -p build_runtime
+        - cd build_runtime
+        - cmake -DZSERIO_RUNTIME_INCLUDE_INSPECTOR=1 ../compiler/extensions/cpp/runtime/ -GNinja
+        - cmake --build . --config Release
+        - ctest -C Release -V --output-on-failure
 
-script:
-  - mkdir -p build_runtime
-  - cd build_runtime
-  - export CC=${CC_COMPILER}
-  - export CXX=${CXX_COMPILER}
-  - cmake -DZSERIO_RUNTIME_INCLUDE_INSPECTOR=1 ../compiler/extensions/cpp/runtime/ -GNinja
-  - cmake --build . --config Release
-  - ctest -C Release -V --output-on-failure
+    # C++ Runtime CppCheck
+    - language: cpp
+      os: linux
+      compiler:
+        - gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+            - cppcheck
+            - ninja-build
+      env:
+        - JOB_NAME=runtime_cppcheck
+        - CC=gcc-4.9
+        - CXX=g++-4.9
+      script:
+        - mkdir -p build_runtime
+        - cd build_runtime
+        - cppcheck ../compiler/extensions/cpp/runtime/
+
+    # Ant Test
+    - language: java
+      os: linux
+      jdk:
+        - oraclejdk8
+      install: true
+      script:
+        - ant test
+      env:
+        - JOB_NAME=ant_test
+
+    # Generated C++ code cppcheck
+    - language: cpp
+      os: linux
+      jdk:
+        - oraclejdk8
+      install: true
+      compiler:
+        - gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+            - cppcheck
+            - ninja-build
+      after_success:
+        - cppcheck --platform=unix64 --enable=all --std=c++11 --max-configs=1 --inconclusive --check-config --suppress=missingIncludeSystem -Ithirdparty/runtime/ --suppress=*:*thirdparty* -Isrc/ src/
+      env:
+        - JOB_NAME=generated_cppcheck
+        - CC=gcc-4.9
+        - CXX=g++-4.9
+      script:
+        - ant install && ant -f compiler/extensions/cpp install && ant zserio_bundle.install
+        - mkdir -p test_cpp_project/thirdparty && cd test_cpp_project/input
+        - java -jar ../../build/zserio/zserio.jar -cpp ../src constraints.zs
+        - cd ..
+        - cp -R ../compiler/extensions/cpp/runtime/src thirdparty/runtime
+        - mkdir -p build && cd build
+        - cmake -DZSERIO_RUNTIME_INCLUDE_INSPECTOR=1 .. -GNinja
+        - cmake --build .
+        - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ script:
   - mkdir -p build_runtime
   - cd build_runtime
   - cmake ../compiler/extensions/cpp/runtime/ -GNinja
-  - cmake --build .
+  - cmake --build . --config Release
+  - ctest -C Release -V
 
 before_install:
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+
+
+# C++ project
+language: cpp
+
+matrix:
+  include:
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env:
+        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+
+before_install:
+  - eval "${MATRIX_EVAL}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 
-
 # C++ project
 language: cpp
 dist: trusty
@@ -8,6 +7,8 @@ matrix:
   include:
     # works on Precise and Trusty
     - os: linux
+      compiler:
+        - gcc
       addons:
         apt:
           sources:
@@ -16,14 +17,14 @@ matrix:
             - g++-4.9
             - ninja-build
       env:
-        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+        - CC_COMPILER=gcc-4.9
+        - CXX_COMPILER=g++-4.9
 
 script:
   - mkdir -p build_runtime
   - cd build_runtime
-  - cmake ../compiler/extensions/cpp/runtime/ -GNinja
+  - export CC=${CC_COMPILER}
+  - export CXX=${CXX_COMPILER}
+  - cmake -DZSERIO_RUNTIME_INCLUDE_INSPECTOR ../compiler/extensions/cpp/runtime/ -GNinja
   - cmake --build . --config Release
   - ctest -C Release -V --output-on-failure
-
-before_install:
-  - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,10 @@ matrix:
       jdk:
         - oraclejdk8
       install: true
-      script:
-        - ant test
       env:
         - JOB_NAME=ant_test
+      script:
+        - ant test
 
     # Generated C++ code cppcheck
     - language: cpp

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ***z*** ero ***seri*** alization ***o*** verhead
 
-[![Build Status](https://travis-ci.org/PeachOS/zserio.svg?branch=master)](https://travis-ci.org/PeachOS/zserio
+[![Build Status](https://travis-ci.org/PeachOS/zserio.svg?branch=master)](https://travis-ci.org/PeachOS/zserio)
 
 --------
 No time to read? Go to the [Quick Start](#quick-start) or [download latest release](https://github.com/ndsev/zserio/releases/latest).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ***z*** ero ***seri*** alization ***o*** verhead
 
+[![Build Status](https://travis-ci.org/PeachOS/zserio.svg?branch=master)](https://travis-ci.org/PeachOS/zserio
+
 --------
 No time to read? Go to the [Quick Start](#quick-start) or [download latest release](https://github.com/ndsev/zserio/releases/latest).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ***z*** ero ***seri*** alization ***o*** verhead
 
-[![Build Status](https://travis-ci.org/PeachOS/zserio.svg?branch=master)](https://travis-ci.org/PeachOS/zserio)
+[![Build Status](https://travis-ci.org/ndsev/zserio.svg?branch=master)](https://travis-ci.org/ndsev/zserio)
 
 --------
 No time to read? Go to the [Quick Start](#quick-start) or [download latest release](https://github.com/ndsev/zserio/releases/latest).

--- a/test_cpp_project/CMakeLists.txt
+++ b/test_cpp_project/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required (VERSION 3.2 FATAL_ERROR)
+project (ZserioTestProject)
+
+add_subdirectory(thirdparty/runtime)
+
+file(GLOB_RECURSE SOURCES_CPP_API "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+file(GLOB_RECURSE HEADERS_CPP_API "${CMAKE_CURRENT_SOURCE_DIR}/src/*.h")
+
+add_library(ZserioTestCpplLib STATIC ${SOURCES_CPP_API} ${HEADERS_CPP_API})
+
+target_include_directories(ZserioTestCpplLib PUBLIC src)
+target_link_libraries(ZserioTestCpplLib ZserioCppRuntime)

--- a/test_cpp_project/input/constraints.zs
+++ b/test_cpp_project/input/constraints.zs
@@ -1,0 +1,4 @@
+package constraints;
+
+import constraints.choice_constraints.*;
+import constraints.structure_constraints.*;

--- a/test_cpp_project/input/constraints/choice_constraints.zs
+++ b/test_cpp_project/input/constraints/choice_constraints.zs
@@ -1,0 +1,10 @@
+package constraints.choice_constraints;
+
+choice ChoiceConstraints(bool selector) on selector
+{
+    case true:
+        uint8   value8  : value8 != 0;
+
+    case false:
+        uint16  value16 : value16 > 255;
+};

--- a/test_cpp_project/input/constraints/structure_constraints.zs
+++ b/test_cpp_project/input/constraints/structure_constraints.zs
@@ -1,0 +1,21 @@
+package constraints.structure_constraints;
+
+enum uint8 BasicColor
+{
+    BLACK,
+    WHITE,
+    RED
+};
+
+struct StructureConstraints
+{
+    BasicColor      blackColor : blackColor == BasicColor.BLACK;
+    BasicColor      whiteColor : whiteColor == BasicColor.WHITE;
+    ExtendedColor   purpleColor : purpleColor == ExtendedColor.PURPLE; // enum defined later
+};
+
+enum uint16 ExtendedColor
+{
+    PURPLE,
+    LIME
+};


### PR DESCRIPTION
This pull request enables some automatic checks for zserio using travis.

It is meant as a first step towards an automated CI that should support future reviews.

Right now this scrip executes the ant tests, C++ specific tests and generates C++ code. Both C++ runtime and generated C++ code are checked by cppcheck. It may (and has to) be extended by other tests later. Does not hurt to have "a few" already in place.

Requirements:
- travis needs to be setup for this project (can't do that, needed before merge)

The pull request is merely a **suggestion** for the ndsev project.

Also added a small badge in the README (which obviously does not show anyrhing yet for this project on the master branch). 
If I replace the ndsev/zserio/master branch with the branch "PeachOS/zserio/travis" (as a preview): [![Build Status](https://travis-ci.org/PeachOS/zserio.svg?branch=travis)](https://travis-ci.org/PeachOS/zserio)

(badge preview leads to the travis status in my fork, where it is already setup)