### PR TITLE
doc-extension: replace cross-frame-access by msg-posting

### DIFF
--- a/compiler/extensions/doc/freemarker/index.html.ftl
+++ b/compiler/extensions/doc/freemarker/index.html.ftl
@@ -1,6 +1,16 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+
+    <script language="JavaScript">
+      function receiveMessage(event) {
+        // forward to overview iframe
+        var f = document.getElementsByName("overview")[0]
+        f.contentWindow.postMessage(event.data, "*")
+      }
+
+      window.addEventListener("message", receiveMessage, false);
+    </script>
   </head>
 
   <frameset cols="20%,*">

--- a/compiler/extensions/doc/freemarker/overview.html.ftl
+++ b/compiler/extensions/doc/freemarker/overview.html.ftl
@@ -68,5 +68,16 @@
             (styleElementSheet.rules)? styleElementSheet.rules : styleElementSheet.cssRules;
         return styleElementRules[0].style;
       }
+
+    function receiveMessage(event)
+    {
+        for (var styleItemId in allPackageNameListStyles)
+        {
+            var styleElementStyle = allPackageNameListStyles[styleItemId];
+            styleElementStyle.display = (event.data === "all" || styleItemId === event.data)? "list-item" : "none";
+        }
+    }
+
+    window.addEventListener("message", receiveMessage, false);
   </script>
 </html>

--- a/compiler/extensions/doc/freemarker/package.html.ftl
+++ b/compiler/extensions/doc/freemarker/package.html.ftl
@@ -25,15 +25,9 @@
         {
             hiliteElement(clickedElement);
 
-            var docToChange = parent.overview;
             var clickedStyleItemId = "style_" +
                 clickedElement.firstChild.firstChild.data.replace(/\./g, '_');
-            for (var styleItemId in docToChange.allPackageNameListStyles)
-            {
-                var styleElementStyle = docToChange.allPackageNameListStyles[styleItemId];
-                styleElementStyle.display =
-                    (styleItemId == clickedStyleItemId)? "list-item" : "none";
-            }
+            parent.postMessage(clickedStyleItemId, "*");
         }
 
 
@@ -41,12 +35,7 @@
         {
             hiliteElement(clickedElement);
 
-            var docToChange = parent.overview;
-            for (var styleItemId in docToChange.allPackageNameListStyles)
-            {
-                var styleElementStyle = docToChange.allPackageNameListStyles[styleItemId];
-                styleElementStyle.display = "list-item";
-            }
+            parent.postMessage("all", "*");
         }
     </script>
   </head>


### PR DESCRIPTION
Cross-document-dom-access is forbidden in all recent browsers. It used to  work in Firefox for local files, but also this behavior is deactivated now, by default (for good reasons).

This patch replaces the direct  cross-frame-access by a messaging-mechanism, which, unfortunately has to be proxied by the frameset (index.html) as there is no chance in accessing parallel frames by their id or name.