### PR TITLE
C++ - Unaligned cache fill

### DIFF
--- a/compiler/extensions/cpp/runtime/src/zserio/BitStreamReader.cpp
+++ b/compiler/extensions/cpp/runtime/src/zserio/BitStreamReader.cpp
@@ -201,11 +201,17 @@ namespace
         {
             checkEof(ctx, numBits);
 
-            ctx.cacheNumBits = static_cast<uint8_t>(ctx.bufferBitSize - ctx.bitIndex);
+            auto alignedBitSize = ctx.bufferBitSize - ctx.bitIndex + 7u;
+            alignedBitSize -= alignedBitSize % 8u;
+
+            ctx.cacheNumBits = static_cast<uint8_t>(alignedBitSize);
             // always aligned to full bytes and less than cacheBitSize
             switch (ctx.cacheNumBits)
             {
 #ifdef ZSERIO_RUNTIME_64BIT
+            case 64:
+                cacheBuffer = parse64(ctx.buffer + byteIndex);
+                break;
             case 56:
                 cacheBuffer = parse56(ctx.buffer + byteIndex);
                 break;

--- a/compiler/extensions/cpp/runtime/src/zserio/BitStreamReader.cpp
+++ b/compiler/extensions/cpp/runtime/src/zserio/BitStreamReader.cpp
@@ -201,12 +201,13 @@ namespace
         {
             checkEof(ctx, numBits);
 
-            auto alignedBitSize = ctx.bufferBitSize - ctx.bitIndex + 7u;
+            ctx.cacheNumBits = static_cast<uint8_t>(ctx.bufferBitSize - ctx.bitIndex);
+
+            auto alignedBitSize = ctx.cacheNumBits + 7u;
             alignedBitSize -= alignedBitSize % 8u;
 
-            ctx.cacheNumBits = static_cast<uint8_t>(alignedBitSize);
             // always aligned to full bytes and less than cacheBitSize
-            switch (ctx.cacheNumBits)
+            switch (alignedBitSize)
             {
 #ifdef ZSERIO_RUNTIME_64BIT
             case 64:
@@ -235,6 +236,8 @@ namespace
                 cacheBuffer = parse8(ctx.buffer + byteIndex);
                 break;
             }
+
+            cacheBuffer >>= alignedBitSize - ctx.cacheNumBits;
         }
     }
 

--- a/compiler/extensions/cpp/runtime/src/zserio/BitStreamWriter.cpp
+++ b/compiler/extensions/cpp/runtime/src/zserio/BitStreamWriter.cpp
@@ -133,7 +133,7 @@ BitStreamWriter::BitStreamWriter(uint8_t* buffer, size_t bufferByteSize) :
 }
 
 BitStreamWriter::BitStreamWriter(BitBuffer& bitBuffer) :
-        BitStreamWriter(bitBuffer.getBuffer(), bitBuffer.getBitSize())
+        BitStreamWriter(bitBuffer.getBuffer(), bitBuffer.getByteSize())
 {
 }
 

--- a/compiler/extensions/cpp/runtime/test/zserio/BitStreamReaderTest.cpp
+++ b/compiler/extensions/cpp/runtime/test/zserio/BitStreamReaderTest.cpp
@@ -26,6 +26,32 @@ private:
 
 const size_t BitStreamReaderTest::BUFFER_SIZE;
 
+TEST_F(BitStreamReaderTest, bitBufferCtor)
+{
+    uint8_t data[] = {1, 2, 3};
+
+    zserio::BitBuffer buffer(data, 17u);
+    zserio::BitStreamReader reader(buffer);
+
+    ASSERT_EQ(17u, reader.getBufferBitSize());
+}
+
+TEST_F(BitStreamReaderTest, readUnalignedData)
+{
+    /* 1bit = 0, 8bit = 8, 8bit = 1 */
+    uint8_t data[] = {0x04, 0x00, 0x80};
+
+    zserio::BitBuffer buffer(data, 17u);
+    zserio::BitStreamReader reader(buffer);
+
+    auto readBool = reader.readBool();
+    ASSERT_EQ(false, readBool);
+
+    zserio::BitBuffer readBuffer = reader.readBitBuffer();
+    ASSERT_EQ(8u, readBuffer.getBitSize());
+    ASSERT_EQ(1u, readBuffer.getBuffer()[0]);
+}
+
 TEST_F(BitStreamReaderTest, readBits)
 {
     // check invalid bitlength acceptance


### PR DESCRIPTION
Fixes two bugs:
- Calling `loadCacheNext` with a cache-size not being a multiple of 8 results in filling the cache with 8 bits without adjusting the caches buffer-bit-size. This leads to value-reads shifted by a wrong number of bits.
- The constructor of `BitStreamWriter` called with an instance of `BitBuffer` sets the bit-size to its byte size, which resulted in out-of-bounds writes in `std::memset`.