### PR TITLE
googletest: Use latest release (v1.10.0) instead of the one from 2013.

### DIFF
--- a/cmake/gtest_utils.cmake
+++ b/cmake/gtest_utils.cmake
@@ -18,8 +18,6 @@ function(gtest_add_library GTEST_ROOT)
     # include google test framework
     add_subdirectory(${GTEST_ROOT} googletest)
 
-    # add include directory
-    target_include_directories(gtest_main SYSTEM PUBLIC ${GTEST_ROOT}/include)
 endfunction()
 
 # A function to add new test to gtest. It is copied from FindGTest.cmake module because include(FindGTest)


### PR DESCRIPTION
zserio - a modern serialization framework - should use recent versions of its dependencies :)
If it turns out that this newest version causes trouble we can also consider using one of the older version from 2016+