### PR TITLE
Java: attach original exception as a cause

### DIFF
--- a/compiler/extensions/java/runtime/src/zserio/runtime/io/ZserioIO.java
+++ b/compiler/extensions/java/runtime/src/zserio/runtime/io/ZserioIO.java
@@ -48,7 +48,7 @@ public final class ZserioIO
         }
         catch (final IOException exc)
         {
-            throw new ZserioError("ZserioIO: " + exc);
+            throw new ZserioError("ZserioIO: " + exc, exc);
         }
     }
 
@@ -71,27 +71,27 @@ public final class ZserioIO
         }
         catch (final SecurityException exc)
         {
-            throw new ZserioError("ZserioIO: " + exc);
+            throw new ZserioError("ZserioIO: " + exc, exc);
         }
         catch (final NoSuchMethodException exc)
         {
-            throw new ZserioError("ZserioIO: " + exc);
+            throw new ZserioError("ZserioIO: " + exc, exc);
         }
         catch (final IllegalArgumentException exc)
         {
-            throw new ZserioError("ZserioIO: " + exc);
+            throw new ZserioError("ZserioIO: " + exc, exc);
         }
         catch (final InstantiationException exc)
         {
-            throw new ZserioError("ZserioIO: " + exc);
+            throw new ZserioError("ZserioIO: " + exc, exc);
         }
         catch (final IllegalAccessException exc)
         {
-            throw new ZserioError("ZserioIO: " + exc);
+            throw new ZserioError("ZserioIO: " + exc, exc);
         }
         catch (final InvocationTargetException exc)
         {
-            throw new ZserioError("ZserioIO: " + exc);
+            throw new ZserioError("ZserioIO: " + exc, exc);
         }
     }
 
@@ -132,19 +132,19 @@ public final class ZserioIO
         }
         catch (final IllegalArgumentException exc)
         {
-            throw new ZserioError("ZserioIO: " + exc);
+            throw new ZserioError("ZserioIO: " + exc, exc);
         }
         catch (final InstantiationException exc)
         {
-            throw new ZserioError("ZserioIO: " + exc);
+            throw new ZserioError("ZserioIO: " + exc, exc);
         }
         catch (final IllegalAccessException exc)
         {
-            throw new ZserioError("ZserioIO: " + exc);
+            throw new ZserioError("ZserioIO: " + exc, exc);
         }
         catch (final InvocationTargetException exc)
         {
-            throw new ZserioError("ZserioIO: " + exc);
+            throw new ZserioError("ZserioIO: " + exc, exc);
         }
     }
 


### PR DESCRIPTION
Currently, there is no possibility to know what caused ZserioError, it only specifies the class of the original exception, but the message and the stacktrace are lost
