### PR TITLE
PackingContext store DeltaContext as optional

### DIFF
--- a/compiler/extensions/cpp/runtime/src/zserio/PackingContext.h
+++ b/compiler/extensions/cpp/runtime/src/zserio/PackingContext.h
@@ -392,7 +392,7 @@ public:
      */
     void createContext()
     {
-        m_context = allocate_unique<DeltaContext>(m_children.get_allocator());
+        m_context = DeltaContext();
     }
 
     /**
@@ -402,7 +402,7 @@ public:
      */
     bool hasContext() const
     {
-        return m_context != nullptr;
+        return m_context.hasValue();
     }
 
     /**
@@ -419,7 +419,7 @@ public:
 
 private:
     Children m_children;
-    unique_ptr<DeltaContext, RebindAlloc<ALLOC, DeltaContext>> m_context;
+    InplaceOptionalHolder<DeltaContext> m_context;
 };
 
 using PackingContextNode = BasicPackingContextNode<>;


### PR DESCRIPTION
This change reduces calls to `malloc` by a lot (from ~5.4k to ~4.4k, one blob) in internal tests (traced vial `callgrind`) with packed data. The effect on the zserio benchmarks is negative though, as they seem to get a bit slower, so I am not sure about this. Maybe it is more cache misses because of the now bigger `PackingContext` object. I have not yet analyzed the benchmarks.

Would it be possible to move the whole `PackingContext` tree creation on the stack, without the use of vectors?