### PR TITLE
build: Fix build script output option

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -554,7 +554,9 @@ main()
     fi
 
     local ANT_PROPS=(-Dzserio.build_dir="${ZSERIO_BUILD_DIR}"
-                     -Dzserio.install_dir="${ZSERIO_DISTR_DIR}")
+                     -Dzserio.install_dir="${ZSERIO_DISTR_DIR}"
+                     -Dzserio_extensions.build_dir="${ZSERIO_BUILD_DIR}/compiler/extensions"
+                     -Dzserio_extensions.install_dir="${ZSERIO_DISTR_DIR}/zserio_libs")
 
     # build Zserio Ant task
     if [[ ${PARAM_ANT_TASK} == 1 ]] ; then


### PR DESCRIPTION
**Please check [contribution guide](https://github.com/ndsev/zserio/CONTRIBUTING.md) first.**

# Description

Using the `build.sh` scripts `-o` flag did not set the `zserio_extensions.{build_dir,install_dir}`, which resulted in a zserio build with the extensions missing.

We switched to using the `build.sh` with the `-o` flag in `zserio-cmake-helper` with commit https://github.com/Klebert-Engineering/zserio-cmake-helper/commit/9a446abc83ac032ecde84fecb0b0d298788f51a6 in favour of calling `ant` directly.

# Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation enhancement
