### PR TITLE
Do not use isSet in isUsed functions

### DIFF
--- a/compiler/extensions/cpp/freemarker/CompoundField.inc.ftl
+++ b/compiler/extensions/cpp/freemarker/CompoundField.inc.ftl
@@ -182,7 +182,7 @@ ${I}}
 </#macro>
 
 <#macro field_optional_condition field>
-    <#if field.optional.clause??>${field.optional.clause}<#else>${field.optional.isSetIndicatorName}()</#if><#t>
+    <#if field.optional.clause??>${field.optional.clause}<#else><@field_member_name field/>.hasValue()</#if><#t>
 </#macro>
 
 <#macro compound_write_field field compoundName indent packed=false>

--- a/compiler/extensions/java/freemarker/Structure.java.ftl
+++ b/compiler/extensions/java/freemarker/Structure.java.ftl
@@ -314,7 +314,7 @@ public class ${name} implements <#rt>
         </#if>
     public boolean ${field.optional.isUsedIndicatorName}()
     {
-        return <#if field.optional.clause??>(${field.optional.clause});<#else>${field.optional.isSetIndicatorName}();</#if>
+        return <#if field.optional.clause??>(${field.optional.clause});<#else>(<@field_member_name field/> != null);</#if>
     }
 
         <#if withWriterCode>

--- a/compiler/extensions/python/freemarker/Structure.py.ftl
+++ b/compiler/extensions/python/freemarker/Structure.py.ftl
@@ -301,7 +301,7 @@ ${I}<#rt>
         """
 
         </#if>
-        return <#if field.optional.clause??>${field.optional.clause}<#else>self.${field.optional.isSetIndicatorName}()</#if>
+        return <#if field.optional.clause??>${field.optional.clause}<#else>not self.<@field_member_name field/> is None</#if>
         <#if withWriterCode>
 
     def ${field.optional.isSetIndicatorName}(self) -> bool:

--- a/test/arguments/without_writer_code/zs/without_writer_code.zs
+++ b/test/arguments/without_writer_code/zs/without_writer_code.zs
@@ -18,6 +18,11 @@ union ExtraParamUnion
     uint32  value32;
 };
 
+struct ItemWithOptionalField
+{
+    optional uint16 opt;
+};
+
 struct Item(ItemType itemType)
 {
     uint16          param;


### PR DESCRIPTION
**Please check [contribution guide](https://github.com/ndsev/zserio/blob/master/CONTRIBUTING.md) first.**

# Description

The `is*Set()` functions are generated for `-withWriterCode` only, but are used without
further checking in `is*Used()` which results in non compiling code if using `optional` fields with `-withoutWriterCode`.

~~Always generate `is*Set()` for optional fields.~~
Alternative would be changing the expression, the C++, Java and Python generators generate for `optionals <type>` members to not call `is*Set()`
but test the optional directly.

The line triggering this bug in the `Structure*.ftl` files is (example from the Python generator, line 304):
```ftl
def ${field.optional.isUsedIndicatorName}(self) -> bool:
  ...
  return <#if field.optional.clause??>${field.optional.clause}<#else>self.${field.optional.isSetIndicatorName}()</#if>
```

I've added an unused `optional ...` field to one of the test-structs, that triggers the bug without this change.

# Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation enhancement
