### PR TITLE
cpp: Store compounds real bit size with its pos

### DIFF
--- a/compiler/extensions/cpp/freemarker/Choice.cpp.ftl
+++ b/compiler/extensions/cpp/freemarker/Choice.cpp.ftl
@@ -291,6 +291,16 @@ ${I}return {};
     </#if>
         }
 
+        size_t realBitSizeOf() const override
+        {
+    <#if withBitPositionCode>
+            return m_object.realBitSizeOf();
+    <#else>
+            throw ::zserio::CppRuntimeException("Reflectable '${name}': ") <<
+                    "Bit position code is disabled by '-withoutBitPositionCode' zserio option!";
+    </#if>
+        }
+
     private:
         <#if isConst>const </#if>${fullName}& m_object;
     };
@@ -590,6 +600,11 @@ void ${name}::write(${name}::ZserioPackingContext&<#if uses_packing_context(fiel
 size_t ${name}::bitPosition() const
 {
     return m_bitPosition;
+}
+
+size_t ${name}::realBitSizeOf() const
+{
+    return m_realBitSize;
 }
 </#if>
 <#if fieldList?has_content>

--- a/compiler/extensions/cpp/freemarker/Choice.h.ftl
+++ b/compiler/extensions/cpp/freemarker/Choice.h.ftl
@@ -343,6 +343,21 @@ public:
      */
     </#if>
     size_t bitPosition() const;
+
+    <#if withCodeComments>
+    /**
+     * Get the bit size of the parsed blob after reading. This size can differ
+     * from the one returned by getBitSizeOf() if compression took place.
+     *
+     * This feature is experimental and can be removed without any warning!
+     *
+     * \note Note that the returned bit size is valid only directly after read! If the Zserio object
+     *       has been changed after reading, the result is unspecified!
+     *
+     * \return Size of the object as it was stored in the blob in bits.
+     */
+    </#if>
+    size_t realBitSizeOf() const;
 </#if>
 
 private:
@@ -360,7 +375,7 @@ private:
     <@compound_constructor_members compoundConstructorsData/>
 <#if withBitPositionCode>
     <#-- Bit position must be before m_objectChoice in order to get initialized first. -->
-    size_t m_bitPosition;
+    size_t m_bitPosition, m_realBitSize;
 </#if>
 <#if fieldList?has_content>
     ${types.anyHolder.name} m_objectChoice;

--- a/compiler/extensions/cpp/freemarker/CompoundConstructor.inc.ftl
+++ b/compiler/extensions/cpp/freemarker/CompoundConstructor.inc.ftl
@@ -36,6 +36,7 @@ ${compoundConstructorsData.compoundName}::${compoundConstructorsData.compoundNam
     </#if>
     <#if withBitPositionCode>
         m_bitPosition(0)
+        m_realBitSize(0)
     </#if>
     <#if memberInitializationMacroName != "">
         <#if (numExtendedFields > 0)>
@@ -102,6 +103,7 @@ ${compoundConstructorsData.compoundName}::${compoundConstructorsData.compoundNam
     </#if>
     <#if withBitPositionCode>
         m_bitPosition(in.getBitPosition())
+        m_realBitSize(0)
     </#if>
     <#if memberInitializationMacroName != "">
         <#if (num_extended_fields(compoundConstructorsData.fieldList) > 0)>
@@ -111,6 +113,14 @@ ${compoundConstructorsData.compoundName}::${compoundConstructorsData.compoundNam
     </#if>
 </@cpp_initializer_list>
 {
+    <#-- Determine the real bit size after member initialization took place. -->
+    <#if withBitPositionCode>
+        <#if packed>
+    m_realBitSize = bitSizeOf(context, m_bitPosition);
+        <#else>
+    m_realBitSize = bitSizeOf();
+        </#if>
+    </#if>
 }
 </#macro>
 
@@ -168,6 +178,7 @@ ${compoundConstructorsData.compoundName}::${compoundConstructorsData.compoundNam
 <@cpp_initializer_list>
     <#if withBitPositionCode>
         m_bitPosition(other.m_bitPosition)
+        m_realBitSize(other.m_realBitSize)
     </#if>
     <#if (num_extended_fields(compoundConstructorsData.fieldList) > 0)>
         m_numExtendedFields(other.m_numExtendedFields)
@@ -191,6 +202,7 @@ ${compoundConstructorsData.compoundName}::${compoundConstructorsData.compoundNam
         m_isInitialized(false)
     <#if withBitPositionCode>
         m_bitPosition(other.m_bitPosition)
+        m_realBitSize(other.m_realBitSize)
     </#if>
     <#if (num_extended_fields(compoundConstructorsData.fieldList) > 0)>
         m_numExtendedFields(other.m_numExtendedFields)
@@ -237,6 +249,7 @@ ${compoundConstructorsData.compoundName}& ${compoundConstructorsData.compoundNam
 {
     <#if withBitPositionCode>
         m_bitPosition = other.m_bitPosition;
+        m_realBitSize = other.m_realBitSize;
     </#if>
     <#if (num_extended_fields(compoundConstructorsData.fieldList) > 0)>
     m_numExtendedFields = other.m_numExtendedFields;
@@ -260,6 +273,7 @@ ${compoundConstructorsData.compoundName}& ${compoundConstructorsData.compoundNam
     m_isInitialized = false;
     <#if withBitPositionCode>
         m_bitPosition = other.m_bitPosition;
+        m_realBitSize = other.m_realBitSize;
     </#if>
     <#if (num_extended_fields(compoundConstructorsData.fieldList) > 0)>
     m_numExtendedFields = other.m_numExtendedFields;
@@ -306,6 +320,7 @@ ${compoundConstructorsData.compoundName}::${compoundConstructorsData.compoundNam
 <@cpp_initializer_list>
     <#if withBitPositionCode>
         m_bitPosition(other.m_bitPosition)
+        m_realBitSize(other.m_realBitSize)
     </#if>
     <#if (num_extended_fields(compoundConstructorsData.fieldList) > 0)>
         m_numExtendedFields(other.m_numExtendedFields)
@@ -329,6 +344,7 @@ ${compoundConstructorsData.compoundName}::${compoundConstructorsData.compoundNam
         m_isInitialized(false)
     <#if withBitPositionCode>
         m_bitPosition(other.m_bitPosition)
+        m_realBitSize(other.m_realBitSize)
     </#if>
     <#if (num_extended_fields(compoundConstructorsData.fieldList) > 0)>
         m_numExtendedFields(other.m_numExtendedFields)
@@ -376,6 +392,7 @@ ${compoundConstructorsData.compoundName}& ${compoundConstructorsData.compoundNam
 {
     <#if withBitPositionCode>
     m_bitPosition = other.m_bitPosition;
+    m_realBitSize = other.m_realBitSize;
     </#if>
     <#if (num_extended_fields(compoundConstructorsData.fieldList) > 0)>
     m_numExtendedFields = other.m_numExtendedFields;
@@ -399,6 +416,7 @@ ${compoundConstructorsData.compoundName}& ${compoundConstructorsData.compoundNam
     m_isInitialized = false;
     <#if withBitPositionCode>
     m_bitPosition = other.m_bitPosition;
+    m_realBitSize = other.m_realBitSize;
     </#if>
     <#if (num_extended_fields(compoundConstructorsData.fieldList) > 0)>
     m_numExtendedFields = other.m_numExtendedFields;
@@ -450,6 +468,7 @@ ${compoundConstructorsData.compoundName}::${compoundConstructorsData.compoundNam
 <@cpp_initializer_list>
     <#if withBitPositionCode>
         m_bitPosition(other.m_bitPosition)
+        m_realBitSize(other.m_realBitSize)
     </#if>
     <#if (num_extended_fields(compoundConstructorsData.fieldList) > 0)>
         m_numExtendedFields(other.m_numExtendedFields)
@@ -478,6 +497,7 @@ ${compoundConstructorsData.compoundName}::${compoundConstructorsData.compoundNam
         m_isInitialized(false)
     <#if withBitPositionCode>
         m_bitPosition(other.m_bitPosition)
+        m_realBitSize(other.m_realBitSize)
     </#if>
     <#if (num_extended_fields(compoundConstructorsData.fieldList) > 0)>
         m_numExtendedFields(other.m_numExtendedFields)

--- a/compiler/extensions/cpp/freemarker/Structure.cpp.ftl
+++ b/compiler/extensions/cpp/freemarker/Structure.cpp.ftl
@@ -244,6 +244,16 @@ const ${types.typeInfo.name}& ${name}::typeInfo()
     </#if>
         }
 
+        size_t realBitSizeOf() const override
+        {
+    <#if withBitPositionCode>
+            return m_object.realBitSizeOf();
+    <#else>
+            throw ::zserio::CppRuntimeException("Reflectable '${name}': ") <<
+                    "Bit position code is disabled by '-withoutBitPositionCode' zserio option!";
+    </#if>
+        }
+
     private:
         <#if isConst>const </#if>${fullName}& m_object;
     };
@@ -573,6 +583,11 @@ void ${name}::write(${name}::ZserioPackingContext&<#if uses_packing_context(fiel
 size_t ${name}::bitPosition() const
 {
     return m_bitPosition;
+}
+
+size_t ${name}::realBitSizeOf() const
+{
+    return m_realBitSize;
 }
 </#if>
 <#if fieldList?has_content>

--- a/compiler/extensions/cpp/freemarker/Structure.h.ftl
+++ b/compiler/extensions/cpp/freemarker/Structure.h.ftl
@@ -394,6 +394,21 @@ public:
      */
     </#if>
     size_t bitPosition() const;
+
+    <#if withCodeComments>
+    /**
+     * Get the bit size of the parsed blob after reading. This size can differ
+     * from the one returned by getBitSizeOf() if compression took place.
+     *
+     * This feature is experimental and can be removed without any warning!
+     *
+     * \note Note that the returned bit size is valid only directly after read! If the Zserio object
+     *       has been changed after reading, the result is unspecified!
+     *
+     * \return Size of the object as it was stored in the blob in bits.
+     */
+    </#if>
+    size_t realBitSizeOf() const;
 </#if>
 
 private:
@@ -421,7 +436,7 @@ private:
     <@compound_constructor_members compoundConstructorsData/>
 <#if withBitPositionCode>
     <#-- Bit position must be before field members in order to get initialized first. -->
-    size_t m_bitPosition;
+    size_t m_bitPosition, m_realBitSize;
 </#if>
 <#if (numExtendedFields > 0)>
     uint32_t m_numExtendedFields;

--- a/compiler/extensions/cpp/freemarker/Union.cpp.ftl
+++ b/compiler/extensions/cpp/freemarker/Union.cpp.ftl
@@ -62,6 +62,7 @@ ${name}::${name}(const ${name}& other)<#rt>
 <@cpp_initializer_list>
     <#if withBitPositionCode>
         m_bitPosition(other.m_bitPosition)
+        m_realBitSize(other.m_realBitSize)
     </#if>
         m_choiceTag(other.m_choiceTag)
     <#list fieldList as field>
@@ -93,6 +94,7 @@ ${name}::${name}(${name}&& other)<#rt>
 <@cpp_initializer_list>
     <#if withBitPositionCode>
         m_bitPosition(other.m_bitPosition)
+        m_realBitSize(other.m_realBitSize)
     </#if>
         m_choiceTag(other.m_choiceTag)
     <#list fieldList as field>
@@ -131,6 +133,7 @@ ${name}::${name}(::zserio::NoInitT, const ${name}& other)<#rt>
     </#if>
     <#if withBitPositionCode>
         m_bitPosition(other.m_bitPosition)
+        m_realBitSize(other.m_realBitSize)
     </#if>
         m_choiceTag(other.m_choiceTag)
     <#list fieldList as field>
@@ -170,6 +173,7 @@ ${name}::${name}(::zserio::NoInitT, ${name}&& other)<#rt>
     </#if>
     <#if withBitPositionCode>
         m_bitPosition(other.m_bitPosition)
+        m_realBitSize(other.m_realBitSize)
     </#if>
         m_choiceTag(other.m_choiceTag)
     <#list fieldList as field>
@@ -207,6 +211,7 @@ ${name}::${name}(::zserio::PropagateAllocatorT,
 <@cpp_initializer_list>
     <#if withBitPositionCode>
         m_bitPosition(other.m_bitPosition)
+        m_realBitSize(other.m_realBitSize)
     </#if>
         m_choiceTag(other.m_choiceTag)
 <#list fieldList as field>
@@ -228,6 +233,7 @@ ${name}::${name}(::zserio::PropagateAllocatorT, ::zserio::NoInitT,
 <@cpp_initializer_list>
     <#if withBitPositionCode>
         m_bitPosition(other.m_bitPosition)
+        m_realBitSize(other.m_realBitSize)
     </#if>
         m_choiceTag(other.m_choiceTag)
     <#list fieldList as field>
@@ -382,6 +388,16 @@ const ${types.typeInfo.name}& ${name}::typeInfo()
         {
     <#if withBitPositionCode>
             return m_object.bitPosition();
+    <#else>
+            throw ::zserio::CppRuntimeException("Reflectable '${name}': ") <<
+                    "Bit position code is disabled by '-withoutBitPositionCode' zserio option!";
+    </#if>
+        }
+
+        size_t realBitSizeOf() const override
+        {
+    <#if withBitPositionCode>
+            return m_object.realBitSizeOf();
     <#else>
             throw ::zserio::CppRuntimeException("Reflectable '${name}': ") <<
                     "Bit position code is disabled by '-withoutBitPositionCode' zserio option!";
@@ -721,6 +737,11 @@ void ${name}::write(${name}::ZserioPackingContext& context, ::zserio::BitStreamW
 size_t ${name}::bitPosition() const
 {
     return m_bitPosition;
+}
+
+size_t ${name}::realBitSizeOf() const
+{
+    return m_realBitSize;
 }
 </#if>
 <#if fieldList?has_content>

--- a/compiler/extensions/cpp/freemarker/Union.h.ftl
+++ b/compiler/extensions/cpp/freemarker/Union.h.ftl
@@ -340,6 +340,21 @@ public:
      */
     </#if>
     size_t bitPosition() const;
+
+    <#if withCodeComments>
+    /**
+     * Get the bit size of the parsed blob after reading. This size can differ
+     * from the one returned by getBitSizeOf() if compression took place.
+     *
+     * This feature is experimental and can be removed without any warning!
+     *
+     * \note Note that the returned bit size is valid only directly after read! If the Zserio object
+     *       has been changed after reading, the result is unspecified!
+     *
+     * \return Size of the object as it was stored in the blob in bits.
+     */
+    </#if>
+    size_t realBitSizeOf() const;
 </#if>
 
 private:
@@ -361,7 +376,7 @@ private:
     <@compound_constructor_members compoundConstructorsData/>
 <#if withBitPositionCode>
     <#-- Bit position must be before m_choiceTag and m_objectChoice in order to get initialized first. -->
-    size_t m_bitPosition;
+    size_t m_bitPosition, m_realBitSize;
 </#if>
     ChoiceTag m_choiceTag;
 <#if fieldList?has_content>

--- a/compiler/extensions/cpp/runtime/ClangTidySuppressions.txt
+++ b/compiler/extensions/cpp/runtime/ClangTidySuppressions.txt
@@ -90,7 +90,7 @@ cppcoreguidelines-pro-type-reinterpret-cast:src/zserio/ValidationSqliteUtil.h:99
 cppcoreguidelines-pro-type-reinterpret-cast:src/zserio/ValidationSqliteUtil.h:100
 
 # This multiple inheritance is intended and we think that to avoid it would mean much more obscure design.
-fuchsia-multiple-inheritance:src/zserio/Reflectable.h:2025
+fuchsia-multiple-inheritance:src/zserio/Reflectable.h:2026
 
 # This is necessary for implementation of low level implementation to mimic standard C++17 abstractions.
 google-explicit-constructor:src/zserio/OptionalHolder.h:232
@@ -122,8 +122,8 @@ misc-no-recursion:src/zserio/JsonParser.h:163
 misc-no-recursion:src/zserio/ReflectableUtil.h:131
 misc-no-recursion:src/zserio/ReflectableUtil.h:135
 misc-no-recursion:src/zserio/ReflectableUtil.h:146
-misc-no-recursion:src/zserio/Reflectable.h:1953
-misc-no-recursion:src/zserio/Reflectable.h:1987
+misc-no-recursion:src/zserio/Reflectable.h:1954
+misc-no-recursion:src/zserio/Reflectable.h:1988
 misc-no-recursion:src/zserio/Walker.h:73
 misc-no-recursion:src/zserio/Walker.h:74
 misc-no-recursion:src/zserio/Walker.h:75

--- a/compiler/extensions/cpp/runtime/src/zserio/IReflectable.h
+++ b/compiler/extensions/cpp/runtime/src/zserio/IReflectable.h
@@ -522,6 +522,20 @@ public:
      * \throw CppRuntimeException If the object was compiled without the bit position feature enabled.
      */
     virtual size_t bitPosition() const = 0;
+
+    /**
+     * Returns the bit size of the parsed blob of the reflectable object.
+     *
+     * This feature is experimental and can be removed without any warning!
+     *
+     * \note Note that the returned bit size is valid only directly after read! If the Zserio object
+     *       has been changed after reading, the result is unspecified!
+     * \note The bit size is only stored for code generated using `-withBitPositionCode` option.
+     *
+     * \return The blob size of the objects in bits.
+     * \throw CppRuntimeException If the object was compiled without the bit position feature enabled.
+     */
+    virtual size_t realBitSizeOf() const = 0;
 };
 
 /** Typedef to reflectable smart pointer needed for convenience in generated code. */

--- a/compiler/extensions/cpp/runtime/src/zserio/Reflectable.h
+++ b/compiler/extensions/cpp/runtime/src/zserio/Reflectable.h
@@ -115,6 +115,7 @@ public:
     string<ALLOC> toString() const override;
 
     size_t bitPosition() const override;
+    size_t realBitSizeOf() const override;
 
 private:
     const IBasicTypeInfo<ALLOC>& m_typeInfo;
@@ -3404,6 +3405,11 @@ public:
         return m_reflectable->bitPosition();
     }
 
+    size_t realBitSizeOf() const override
+    {
+        return m_reflectable->realBitSizeOf();
+    }
+
 private:
     T m_object;
     IBasicReflectablePtr<ALLOC> m_reflectable;
@@ -4379,6 +4385,13 @@ template <typename ALLOC>
 size_t ReflectableBase<ALLOC>::bitPosition() const
 {
     throw CppRuntimeException("Bit position is not available for type '")
+            << getTypeInfo().getSchemaName() << "'!";
+}
+
+template <typename ALLOC>
+size_t ReflectableBase<ALLOC>::realBitSizeOf() const
+{
+    throw CppRuntimeException("Real bit size is not available for type '")
             << getTypeInfo().getSchemaName() << "'!";
 }
 


### PR DESCRIPTION
**Please check [contribution guide](https://github.com/ndsev/zserio/blob/master/CONTRIBUTING.md) first.**

# Description

With the implementation of `bitPosition()`, I did not take relative encoded arrays/packed objects into account. The proposed solution is to store the "physical bit-size" of an object along with its bit-position, because we cannot call `bitSizeOf(context, offset)` at a later stage.

This PR adds a second field `m_realBitSize` that stores the physical bit-size of an object on construction.

I am not sure about the name `realBitPosition()`, maybe `physicalSizeOf()` or `packedSizeOf()` is better?

Tests are yet missing. I will add them to this PR.

# Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation enhancement
