### PR TITLE
Replace pkg_resources requirement checks

### DIFF
--- a/.github/workflows/build_linux_python.yml
+++ b/.github/workflows/build_linux_python.yml
@@ -45,7 +45,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install virtualenv
-        python -m pip install setuptools==81.0.0 # necessary for pkg_resources on Python 3.12, removed in 82.0.0
 
     - name: "Checkout"
       uses: actions/checkout@v4

--- a/.github/workflows/build_windows_python.yml
+++ b/.github/workflows/build_windows_python.yml
@@ -64,7 +64,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install virtualenv
-        python -m pip install setuptools==81.0.0 # necessary for pkg_resources on Python 3.12, removed in 82.0.0
 
     - name: "Convert environment variables to POSIX paths"
       shell: bash

--- a/scripts/common_tools.sh
+++ b/scripts/common_tools.sh
@@ -244,8 +244,6 @@ check_python_version()
 }
 
 # Check python requirements.
-#
-# Note: From Python 3.12, setuptools must be installed.
 check_python_requirements()
 {
     exit_if_argc_ne $# 2
@@ -255,13 +253,48 @@ check_python_requirements()
 
     "${PYTHON_BIN}" << EOF
 try:
+    import re
     import sys
-    import pkg_resources
+    from importlib.metadata import PackageNotFoundError, version
+
+    def parse_requirement(requirement):
+        for operator in ("==", ">="):
+            if operator in requirement:
+                name, required_version = requirement.split(operator, 1)
+                return name.strip(), operator, required_version.strip()
+
+        return requirement.strip(), None, None
+
+    def normalize_version(value):
+        return [
+            (0, int(part)) if part.isdigit() else (1, part.lower())
+            for part in re.split(r"[._+-]", value)
+            if part
+        ]
+
+    def version_at_least(installed_version, required_version):
+        installed_parts = normalize_version(installed_version)
+        required_parts = normalize_version(required_version)
+        length = max(len(installed_parts), len(required_parts))
+        installed_parts += [(0, 0)] * (length - len(installed_parts))
+        required_parts += [(0, 0)] * (length - len(required_parts))
+        return installed_parts >= required_parts
+
     reqs = "${PYTHON_REQUIREMENTS[@]}".split()
-    pkg_resources.require(reqs)
+    for req in reqs:
+        name, operator, required_version = parse_requirement(req)
+        try:
+            installed_version = version(name)
+        except PackageNotFoundError as exc:
+            raise RuntimeError(f"Missing required package: {name}") from exc
+
+        if operator == "==" and installed_version != required_version:
+            raise RuntimeError(f"{name} {installed_version} does not satisfy {req}")
+        if operator == ">=" and not version_at_least(installed_version, required_version):
+            raise RuntimeError(f"{name} {installed_version} does not satisfy {req}")
 except Exception as e:
     print(e, file=sys.stderr)
-    exit(1)
+    sys.exit(1)
 EOF
     if [ $? -ne 0 ] ; then
         stderr_echo "Required python packages are not installed!"

--- a/scripts/common_tools.sh
+++ b/scripts/common_tools.sh
@@ -159,7 +159,7 @@ set_global_python_variables()
         fi
 
         # check that python pip and virtualenv modules are installed
-        local PYTHON_REQUIREMENTS=("virtualenv" "pip")
+        local PYTHON_REQUIREMENTS=("virtualenv" "pip" "packaging")
         check_python_requirements "${PYTHON}" PYTHON_REQUIREMENTS[@]
         if [ $? -ne 0 ] ; then
             return 1
@@ -256,6 +256,7 @@ try:
     import re
     import sys
     from importlib.metadata import PackageNotFoundError, version
+    from packaging.version import parse as parse_version
 
     def parse_requirement(requirement):
         for operator in ("==", ">="):
@@ -264,21 +265,6 @@ try:
                 return name.strip(), operator, required_version.strip()
 
         return requirement.strip(), None, None
-
-    def normalize_version(value):
-        return [
-            (0, int(part)) if part.isdigit() else (1, part.lower())
-            for part in re.split(r"[._+-]", value)
-            if part
-        ]
-
-    def version_at_least(installed_version, required_version):
-        installed_parts = normalize_version(installed_version)
-        required_parts = normalize_version(required_version)
-        length = max(len(installed_parts), len(required_parts))
-        installed_parts += [(0, 0)] * (length - len(installed_parts))
-        required_parts += [(0, 0)] * (length - len(required_parts))
-        return installed_parts >= required_parts
 
     reqs = "${PYTHON_REQUIREMENTS[@]}".split()
     for req in reqs:
@@ -290,7 +276,7 @@ try:
 
         if operator == "==" and installed_version != required_version:
             raise RuntimeError(f"{name} {installed_version} does not satisfy {req}")
-        if operator == ">=" and not version_at_least(installed_version, required_version):
+        if operator == ">=" and parse_version(installed_version) < parse_version(required_version):
             raise RuntimeError(f"{name} {installed_version} does not satisfy {req}")
 except Exception as e:
     print(e, file=sys.stderr)
@@ -379,6 +365,7 @@ activate_python_virtualenv()
         "astroid==3.0.3" "pylint==3.0.3" "mypy==0.931"
         "pybind11>=2.10.0"
         "black==24.4.2"
+        "packaging"
     )
     local APSW_REQUIREMENTS=("apsw")
 

--- a/scripts/test_compat_api.sh
+++ b/scripts/test_compat_api.sh
@@ -53,6 +53,60 @@ get_old_sources()
     return 0
 }
 
+# Update dependency bootstrap in old sources if they still rely on pkg_resources.
+update_old_sources_python_requirements_check()
+{
+    exit_if_argc_ne $# 2
+    local ZSERIO_PROJECT_ROOT="$1"; shift
+    local OLD_VERSION_DIR="$1"; shift
+
+    local OLD_COMMON_TOOLS="${OLD_VERSION_DIR}/scripts/common_tools.sh"
+    if ! grep "import pkg_resources" "${OLD_COMMON_TOOLS}" > /dev/null ; then
+        return 0
+    fi
+
+    python - "${ZSERIO_PROJECT_ROOT}/scripts/common_tools.sh" "${OLD_COMMON_TOOLS}" <<'PYTHON'
+import re
+import sys
+
+current_common_tools_path, old_common_tools_path = sys.argv[1:]
+
+
+def read_text(path):
+    with open(path, "r", encoding="utf-8") as text_file:
+        return text_file.read()
+
+
+def replace_check_python_requirements(current_common_tools, old_common_tools):
+    pattern = re.compile(
+        r"check_python_requirements\(\)\n\{\n.*?\n\}\n\n"
+        r"(?=# Detect path to python virtualenv activate scripts)",
+        re.DOTALL,
+    )
+
+    current_match = pattern.search(current_common_tools)
+    old_match = pattern.search(old_common_tools)
+    if current_match is None or old_match is None:
+        raise RuntimeError("Failed to locate check_python_requirements in common_tools.sh")
+
+    return pattern.sub(current_match.group(0), old_common_tools, count=1)
+
+
+current_common_tools = read_text(current_common_tools_path)
+old_common_tools = read_text(old_common_tools_path)
+updated_common_tools = replace_check_python_requirements(current_common_tools, old_common_tools)
+
+with open(old_common_tools_path, "w", encoding="utf-8", newline="") as text_file:
+    text_file.write(updated_common_tools)
+PYTHON
+    if [ $? -ne 0 ] ; then
+        stderr_echo "Failed to update python requirements check in old sources!"
+        return 1
+    fi
+
+    return 0
+}
+
 # Copy new release into directory with old sources.
 copy_new_release()
 {
@@ -276,6 +330,12 @@ main()
     # get old version sources
     local OLD_VERSION_DIR="${TEST_OUT_DIR}/${OLD_VERSION_BRANCH}"
     get_old_sources "${OLD_VERSION_DIR}" "${OLD_VERSION_BRANCH}"
+    if [ $? -ne 0 ] ; then
+        return 1
+    fi
+
+    # Keep compatibility tests runnable on current Python without restoring workflow-level setuptools installs.
+    update_old_sources_python_requirements_check "${ZSERIO_PROJECT_ROOT}" "${OLD_VERSION_DIR}"
     if [ $? -ne 0 ] ; then
         return 1
     fi


### PR DESCRIPTION
## Summary
- replace the `pkg_resources.require()` check with an `importlib.metadata` based check for the requirement forms used by the build scripts
- remove the Linux and Windows Python workflow `setuptools==81.0.0` installs that were only needed for `pkg_resources`
- keep API compatibility checks runnable against older release sources by updating their dependency bootstrap before running the old tests

Fixes #721

## Validation
- `git diff --check HEAD~2..HEAD`
- `rg -n "setuptools==81.0.0|necessary for pkg_resources" scripts .github -S` (no matches)
- Remote CI pending after the latest push
- Not run locally
